### PR TITLE
Improve navigation and theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flutter Web Portfolio
 
-This project is a personal portfolio built with Flutter Web. It now includes an animated navigation drawer with quick links to each section and a cleaner theme using Google Fonts.
+This project is a personal portfolio built with Flutter Web. It now includes an animated navigation drawer with quick links to each section and a cleaner theme using Google Fonts. The layout features subtle shadows and hover effects for a professional feel, and project cards animate into view as you scroll.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
+# Flutter Web Portfolio
 
+This project is a personal portfolio built with Flutter Web. It now includes an animated navigation drawer with quick links to each section and a cleaner theme using Google Fonts.
+
+## Running
+
+Run `flutter run -d chrome` to launch the web application.

--- a/lib/components/animated_section.dart
+++ b/lib/components/animated_section.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+/// A simple fade and slide animation wrapper used for page sections.
+class AnimatedSection extends StatelessWidget {
+  final Widget child;
+  final Key? sectionKey;
+  final Duration duration;
+
+  const AnimatedSection({
+    this.sectionKey,
+    required this.child,
+    this.duration = const Duration(milliseconds: 600),
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween(begin: 0, end: 1),
+      duration: duration,
+      builder: (context, value, inner) => Opacity(
+        opacity: value,
+        child: Transform.translate(
+          offset: Offset(0, 30 * (1 - value)),
+          child: inner,
+        ),
+      ),
+      child: Container(key: sectionKey, child: child),
+    );
+  }
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -15,8 +15,8 @@ const maxWidth = 1440.0; // max width of our web
 /// Default shadow used on cards to provide separation from the background
 const List<BoxShadow> kDefaultCardShadow = [
   BoxShadow(
-    offset: Offset(0, 4),
-    blurRadius: 12,
-    color: Color(0x1A000000), // 10% opacity black
+    offset: Offset(0, 8),
+    blurRadius: 24,
+    color: Color(0x33000000), // 20% opacity black
   ),
 ];

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 
 // Light theme palette with better contrast
-const primaryColor = Color(0xFF4C7BF2); // accent color
+// Updated palette for better readability
+const primaryColor = Color(0xFF0066FF); // accent color
 const secondaryColor = Color(0xFFFFFFFF); // card backgrounds
-const darkColor = Color(0xFFD1D5DB); // subtle borders & dividers
-const bodyTextColor = Color(0xFF333333); // high contrast text
-const bgColor = Color(0xFFF5F7FA); // page background
+const darkColor = Color(0xFFE5E7EB); // subtle borders & dividers
+const bodyTextColor = Color(0xFF202124); // high contrast text
+const bgColor = Color(0xFFF9FAFB); // page background
 
 const defaultPadding = 20.0;
 const defaultDuration = Duration(seconds: 1); // we use it on our animation

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_profile/screens/home/home_screen.dart';
 import 'package:flutter_profile/screens/main/main_screen.dart';
-//import 'package:google_fonts/google_fonts.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import 'constants.dart';
 
@@ -16,13 +16,13 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'msw\'s  portfolio',
-      theme: ThemeData.light().copyWith(
+      theme: ThemeData(
         primaryColor: primaryColor,
         scaffoldBackgroundColor: bgColor,
         canvasColor: bgColor,
-        textTheme: ThemeData.light()
-            .textTheme
-            .apply(bodyColor: bodyTextColor, displayColor: bodyTextColor),
+        textTheme: GoogleFonts.notoSansKrTextTheme(
+          ThemeData.light().textTheme,
+        ).apply(bodyColor: bodyTextColor, displayColor: bodyTextColor),
       ),
       home: HomeScreen(),
     );

--- a/lib/models/Recommendation.dart
+++ b/lib/models/Recommendation.dart
@@ -14,7 +14,7 @@ final List<Recommendation> demo_recommendations = [
     name: "로완",
     source: "",
     text: "의료기기 어플리케이션 개발,",
-    period: "2023-11월 ~ 재직중(1년 6개월)",
+    period: "2023-11월 ~ 재직중",
   ),
 ];
 

--- a/lib/screens/home/components/my_projects.dart
+++ b/lib/screens/home/components/my_projects.dart
@@ -4,7 +4,7 @@ import 'package:flutter_profile/responsive.dart';
 
 import '../../../constants.dart';
 import 'project_card.dart';
-import '../../components/animated_section.dart';
+import '../../../components/animated_section.dart';
 
 class MyProjects extends StatelessWidget {
   const MyProjects({

--- a/lib/screens/home/components/my_projects.dart
+++ b/lib/screens/home/components/my_projects.dart
@@ -4,6 +4,7 @@ import 'package:flutter_profile/responsive.dart';
 
 import '../../../constants.dart';
 import 'project_card.dart';
+import '../../components/animated_section.dart';
 
 class MyProjects extends StatelessWidget {
   const MyProjects({
@@ -56,8 +57,10 @@ class ProjectsGridView extends StatelessWidget {
         crossAxisSpacing: defaultPadding,
         mainAxisSpacing: defaultPadding,
       ),
-      itemBuilder: (context, index) => ProjectCard(
-        project: demo_projects[index],
+      itemBuilder: (context, index) => AnimatedSection(
+        child: ProjectCard(
+          project: demo_projects[index],
+        ),
       ),
     );
   }

--- a/lib/screens/home/components/projects.dart
+++ b/lib/screens/home/components/projects.dart
@@ -8,7 +8,7 @@ import '../../../models/Project.dart';
 import 'ProjectsCart.dart';
 import '../../main/components/skills.dart';
 import '../../main/components/coding.dart';
-import '../../components/animated_section.dart';
+import '../../../components/animated_section.dart';
 
 class Projects extends StatelessWidget {
   const Projects({

--- a/lib/screens/home/components/projects.dart
+++ b/lib/screens/home/components/projects.dart
@@ -6,6 +6,9 @@ import 'package:flutter_profile/screens/home/components/recommendation_card.dart
 import '../../../constants.dart';
 import '../../../models/Project.dart';
 import 'ProjectsCart.dart';
+import '../../main/components/skills.dart';
+import '../../main/components/coding.dart';
+import '../../components/animated_section.dart';
 
 class Projects extends StatelessWidget {
   const Projects({
@@ -17,15 +20,14 @@ class Projects extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: defaultPadding),
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            "Projects\n",
+            'Projects',
             style: Theme.of(context).textTheme.headlineSmall,
           ),
           Text(
-            "보유 기술 (Technical Skills)\n",
+            '보유 기술 (Technical Skills)',
             style: Theme.of(context).textTheme.titleLarge,
           ),
           Text(
@@ -33,48 +35,27 @@ class Projects extends StatelessWidget {
       Frontend: QT, Flutter
       Database: SQLite, Firebase
       Version Control: Git, GitHub
-      Package : GetX, Riverpod, Go Router, Hooks, easy_localization, 
-          ''',
+      Package : GetX, Riverpod, Go Router, Hooks, easy_localization,
+      ''',
             style: TextStyle(height: 1.5),
           ),
           const SizedBox(height: defaultPadding),
-          SingleChildScrollView(
-              child: ListView.builder(
+          Skills(),
+          SizedBox(height: defaultPadding),
+          Coding(),
+          const SizedBox(height: defaultPadding),
+          ListView.builder(
             shrinkWrap: true,
+            physics: NeverScrollableScrollPhysics(),
             itemBuilder: (context, index) {
-              return ProjectsCard(
-                recommendation: projects[index],
+              return AnimatedSection(
+                child: ProjectsCard(
+                  recommendation: projects[index],
+                ),
               );
             },
             itemCount: projects.length,
-          )
-
-              /*  Column(
-          children: [
-          RecommendationCard(
-          recommendation: demo_recommendations[0],
           ),
-        ],
-      ),
-    )
-    SingleChildScrollView(
-      scrollDirection: Axis.vertical,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-
-        ]  List.generate(
-        demo_recommendations.length,
-            (index) => Padding(
-          padding: const EdgeInsets.only(right: defaultPadding),
-          child: RecommendationCard(
-            recommendation: demo_recommendations[index],
-          ),
-        ),
-      ),
-    ),*/
-              ),
         ],
       ),
     );

--- a/lib/screens/home/components/recommendations.dart
+++ b/lib/screens/home/components/recommendations.dart
@@ -24,14 +24,17 @@ class Recommendations extends StatelessWidget {
           const SizedBox(height: defaultPadding),
           SingleChildScrollView(
             child: Column(
-              children: [
-                RecommendationCard(
-                  recommendation: demo_recommendations[0],
-                ),
-                RecommendationCard(
-                  recommendation: demo_recommendations[1],
-                ),
-              ],
+              children: List.generate(
+                demo_recommendations.length,
+                (index) {
+                  return Padding(
+                    padding: EdgeInsets.only(bottom: 10),
+                    child: RecommendationCard(
+                      recommendation: demo_recommendations[index],
+                    ),
+                  );
+                },
+              ),
             ),
           )
           /*  SingleChildScrollView(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -2,22 +2,48 @@ import 'package:flutter/material.dart';
 import 'package:flutter_profile/screens/home/components/my_blog.dart';
 import 'package:flutter_profile/screens/home/components/projects.dart';
 import 'package:flutter_profile/screens/main/main_screen.dart';
-import 'components/home_banner.dart';
+import '../../components/animated_section.dart';
 import 'components/my_projects.dart';
 import 'components/recommendations.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final ScrollController _scrollController = ScrollController();
+  final _careerKey = GlobalKey();
+  final _projectKey = GlobalKey();
+  final _toyKey = GlobalKey();
+  final _postKey = GlobalKey();
+
+  void _onMenu(String id) {
+    final contextMap = {
+      'career': _careerKey,
+      'projects': _projectKey,
+      'toys': _toyKey,
+      'posts': _postKey,
+    };
+    final key = contextMap[id];
+    if (key != null && key.currentContext != null) {
+      Scrollable.ensureVisible(key.currentContext!,
+          duration: const Duration(milliseconds: 500));
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return MainScreen(
+      scrollController: _scrollController,
+      onMenuTap: _onMenu,
       children: [
-        // HomeBanner(),
-        Recommendations(),
-        Projects(),
-        MyProjects(),
-        MyPost(),
+        AnimatedSection(sectionKey: _careerKey, child: Recommendations()),
+        AnimatedSection(sectionKey: _projectKey, child: Projects()),
+        AnimatedSection(sectionKey: _toyKey, child: MyProjects()),
+        AnimatedSection(sectionKey: _postKey, child: MyPost()),
       ],
     );
   }

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_profile/screens/home/components/my_blog.dart';
 import 'package:flutter_profile/screens/home/components/projects.dart';
 import 'package:flutter_profile/screens/main/main_screen.dart';
 import '../../components/animated_section.dart';
+import 'components/home_banner.dart';
 import 'components/my_projects.dart';
 import 'components/recommendations.dart';
 
@@ -15,6 +16,8 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   final ScrollController _scrollController = ScrollController();
+  final _aboutMe = GlobalKey();
+  final _skillKey = GlobalKey();
   final _careerKey = GlobalKey();
   final _projectKey = GlobalKey();
   final _toyKey = GlobalKey();
@@ -29,8 +32,7 @@ class _HomeScreenState extends State<HomeScreen> {
     };
     final key = contextMap[id];
     if (key != null && key.currentContext != null) {
-      Scrollable.ensureVisible(key.currentContext!,
-          duration: const Duration(milliseconds: 500));
+      Scrollable.ensureVisible(key.currentContext!, duration: const Duration(milliseconds: 500));
     }
   }
 
@@ -40,6 +42,9 @@ class _HomeScreenState extends State<HomeScreen> {
       scrollController: _scrollController,
       onMenuTap: _onMenu,
       children: [
+        HomeBanner(),
+        AnimatedSection(sectionKey: _aboutMe, child: Container()),
+        AnimatedSection(sectionKey: _skillKey, child: Container()),
         AnimatedSection(sectionKey: _careerKey, child: Recommendations()),
         AnimatedSection(sectionKey: _projectKey, child: Projects()),
         AnimatedSection(sectionKey: _toyKey, child: MyProjects()),

--- a/lib/screens/main/components/my_info.dart
+++ b/lib/screens/main/components/my_info.dart
@@ -10,9 +10,9 @@ class MyInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: secondaryColor,
+        //color: secondaryColor,
         borderRadius: BorderRadius.circular(8),
-        boxShadow: kDefaultCardShadow,
+        //boxShadow: kDefaultCardShadow,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -11,7 +11,10 @@ import 'skills.dart';
 class SideMenu extends StatelessWidget {
   const SideMenu({
     Key? key,
+    this.onMenuTap,
   }) : super(key: key);
+
+  final void Function(String id)? onMenuTap;
 
   @override
   Widget build(BuildContext context) {
@@ -60,6 +63,28 @@ class SideMenu extends StatelessWidget {
                     Skills(),
                     SizedBox(height: defaultPadding),
                     Coding(),
+                    Divider(),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ListTile(
+                          title: const Text('Career'),
+                          onTap: () => onMenuTap?.call('career'),
+                        ),
+                        ListTile(
+                          title: const Text('Projects'),
+                          onTap: () => onMenuTap?.call('projects'),
+                        ),
+                        ListTile(
+                          title: const Text('Toy Projects'),
+                          onTap: () => onMenuTap?.call('toys'),
+                        ),
+                        ListTile(
+                          title: const Text('Posts'),
+                          onTap: () => onMenuTap?.call('posts'),
+                        ),
+                      ],
+                    ),
                     Divider(),
                     SizedBox(height: defaultPadding / 2),
                     Container(

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -22,7 +22,6 @@ class SideMenu extends StatelessWidget {
             Flexible(
               fit: FlexFit.loose,
               child: Container(
-                //height: MediaQuery.of(context).size.height * 0.45,
                 child: MyInfo(),
               ),
             ),
@@ -36,6 +35,14 @@ class SideMenu extends StatelessWidget {
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
+                        _MenuButton(
+                          label: 'About Me',
+                          onTap: () => onMenuTap?.call('aboutMe'),
+                        ),
+                        _MenuButton(
+                          label: 'Skill',
+                          onTap: () => onMenuTap?.call('skill'),
+                        ),
                         _MenuButton(
                           label: 'Career',
                           onTap: () => onMenuTap?.call('career'),

--- a/lib/screens/main/components/side_menu.dart
+++ b/lib/screens/main/components/side_menu.dart
@@ -3,10 +3,7 @@ import 'package:flutter_profile/constants.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'area_info_text.dart';
-import 'coding.dart';
 import 'my_info.dart';
-import 'skills.dart';
 
 class SideMenu extends StatelessWidget {
   const SideMenu({
@@ -34,53 +31,25 @@ class SideMenu extends StatelessWidget {
                 padding: EdgeInsets.all(defaultPadding),
                 child: Column(
                   children: [
-                    Container(
-                      height: MediaQuery.of(context).size.height * 0.15,
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Expanded(
-                            child: AreaInfoText(
-                              title: "Residence",
-                              text: "Korea",
-                            ),
-                          ),
-                          Expanded(
-                            child: AreaInfoText(
-                              title: "City",
-                              text: "Seoul",
-                            ),
-                          ),
-                          Expanded(
-                            child: AreaInfoText(
-                              title: "Age",
-                              text: age(1998).toString(),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Skills(),
                     SizedBox(height: defaultPadding),
-                    Coding(),
                     Divider(),
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        ListTile(
-                          title: const Text('Career'),
+                        _MenuButton(
+                          label: 'Career',
                           onTap: () => onMenuTap?.call('career'),
                         ),
-                        ListTile(
-                          title: const Text('Projects'),
+                        _MenuButton(
+                          label: 'Projects',
                           onTap: () => onMenuTap?.call('projects'),
                         ),
-                        ListTile(
-                          title: const Text('Toy Projects'),
+                        _MenuButton(
+                          label: 'Toy Projects',
                           onTap: () => onMenuTap?.call('toys'),
                         ),
-                        ListTile(
-                          title: const Text('Posts'),
+                        _MenuButton(
+                          label: 'Posts',
                           onTap: () => onMenuTap?.call('posts'),
                         ),
                       ],
@@ -128,8 +97,36 @@ class SideMenu extends StatelessWidget {
   goLink(String link) async {
     if (!await launch(link)) throw 'Could not launch $link';
   }
+}
 
-  int age(int year) {
-    return DateTime.now().year - year;
+class _MenuButton extends StatefulWidget {
+  final String label;
+  final VoidCallback? onTap;
+  const _MenuButton({required this.label, this.onTap});
+
+  @override
+  State<_MenuButton> createState() => _MenuButtonState();
+}
+
+class _MenuButtonState extends State<_MenuButton> {
+  bool _hover = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() => _hover = false),
+      child: ListTile(
+        title: Text(
+          widget.label,
+          style: TextStyle(
+            color: _hover ? primaryColor : bodyTextColor,
+            fontWeight: _hover ? FontWeight.bold : FontWeight.normal,
+          ),
+        ),
+        tileColor: _hover ? primaryColor.withOpacity(0.1) : Colors.transparent,
+        onTap: widget.onTap,
+      ),
+    );
   }
 }

--- a/lib/screens/main/main_screen.dart
+++ b/lib/screens/main/main_screen.dart
@@ -5,9 +5,16 @@ import 'package:flutter_profile/responsive.dart';
 import 'components/side_menu.dart';
 
 class MainScreen extends StatelessWidget {
-  const MainScreen({Key? key, required this.children}) : super(key: key);
+  const MainScreen({
+    Key? key,
+    required this.children,
+    this.scrollController,
+    this.onMenuTap,
+  }) : super(key: key);
 
   final List<Widget> children;
+  final ScrollController? scrollController;
+  final void Function(String id)? onMenuTap;
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +33,7 @@ class MainScreen extends StatelessWidget {
                 ),
               ),
             ),
-      drawer: SideMenu(),
+      drawer: SideMenu(onMenuTap: onMenuTap),
       body: Center(
         child: Container(
           constraints: BoxConstraints(maxWidth: maxWidth),
@@ -36,12 +43,13 @@ class MainScreen extends StatelessWidget {
               if (Responsive.isDesktop(context))
                 Expanded(
                   flex: 2,
-                  child: SideMenu(),
+                  child: SideMenu(onMenuTap: onMenuTap),
                 ),
               SizedBox(width: defaultPadding),
               Expanded(
                 flex: 7,
                 child: SingleChildScrollView(
+                  controller: scrollController,
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -140,6 +140,7 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
+      sha256: f0b8d115a13ecf827013ec9fc883390ccc0e87a96ed5347a3114cac177ef18e8
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
@@ -155,10 +156,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: b6f1f143a71e1fe1b34670f1acd6f13960ade2557c96b87e127e0cf661969791
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.3"
+    version: "1.4.0"
   http_parser:
     dependency: transitive
     description:
@@ -271,14 +272,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "8f6460c77a98ad2807cd3b98c67096db4286f56166852d0ce5951bb600a63594"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:
@@ -476,6 +469,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -140,10 +140,9 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: c31d49dfbcef1a84592128d2d9e8767eebf5a919ac1e6f77d14dc36790ef1639
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "6.1.0"
   html:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_profile
 description: A new Flutter project.
 
-# The following line prevents the package from being accidentally published to
+# The following line prevents the package from being accidentally published t
 # pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  google_fonts: ^2.1.0
+  # Updated to latest version for Flutter 3 compatibility
+  google_fonts: ^6.1.0
   flutter_svg: ^2.0.0
   animated_text_kit: ^4.2.1
   url_launcher: ^6.0.18


### PR DESCRIPTION
## Summary
- add an `AnimatedSection` widget for fade/slide transitions
- update main theme to use Google Fonts and a lighter color palette
- convert `HomeScreen` to StatefulWidget with section navigation
- extend `MainScreen` and `SideMenu` to support menu callbacks and scrolling
- document running instructions in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2386a4d8832dbe1d93561ba44b2a