### PR TITLE
Implement random skill bars and scroll animation

### DIFF
--- a/lib/models/skill.dart
+++ b/lib/models/skill.dart
@@ -1,0 +1,16 @@
+class Skill {
+  final String name;
+  final double level; // 0..1
+  final String description;
+
+  Skill({required this.name, required this.level, required this.description});
+}
+
+final List<Skill> demoSkills = [
+  Skill(name: 'Flutter', level: 0.7, description: 'Cross-platform UI toolkit'),
+  Skill(name: 'Firebase', level: 0.3, description: 'Backend & realtime DB'),
+  Skill(name: 'Qt', level: 0.3, description: 'C++ framework'),
+  Skill(name: 'Dart', level: 0.7, description: 'Primary programming language'),
+  Skill(name: 'Git', level: 0.3, description: 'Version control'),
+  Skill(name: 'Java', level: 0.2, description: 'Additional language'),
+];

--- a/lib/screens/home/components/projects.dart
+++ b/lib/screens/home/components/projects.dart
@@ -1,19 +1,42 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_profile/models/Recommendation.dart';
 import 'package:flutter_profile/screens/home/components/project_card.dart';
-import 'package:flutter_profile/screens/home/components/recommendation_card.dart';
 
 import '../../../constants.dart';
 import '../../../models/Project.dart';
 import 'ProjectsCart.dart';
-import '../../main/components/skills.dart';
-import '../../main/components/coding.dart';
-import '../../../components/animated_section.dart';
 
-class Projects extends StatelessWidget {
-  const Projects({
-    Key? key,
-  }) : super(key: key);
+class Projects extends StatefulWidget {
+  final ScrollController scrollController;
+  const Projects({Key? key, required this.scrollController}) : super(key: key);
+
+  @override
+  State<Projects> createState() => _ProjectsState();
+}
+
+class _ProjectsState extends State<Projects> {
+  late List<bool> _visible;
+
+  @override
+  void initState() {
+    super.initState();
+    _visible = List<bool>.filled(projects.length, false);
+    widget.scrollController.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    final index = (widget.scrollController.offset / 300).floor();
+    for (int i = 0; i <= index && i < _visible.length; i++) {
+      if (!_visible[i]) {
+        setState(() => _visible[i] = true);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(_onScroll);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -26,35 +49,27 @@ class Projects extends StatelessWidget {
             'Projects',
             style: Theme.of(context).textTheme.headlineSmall,
           ),
-          Text(
-            '보유 기술 (Technical Skills)',
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          Text(
-            '''
-      Frontend: QT, Flutter
-      Database: SQLite, Firebase
-      Version Control: Git, GitHub
-      Package : GetX, Riverpod, Go Router, Hooks, easy_localization,
-      ''',
-            style: TextStyle(height: 1.5),
-          ),
-          const SizedBox(height: defaultPadding),
-          Skills(),
-          SizedBox(height: defaultPadding),
-          Coding(),
           const SizedBox(height: defaultPadding),
           ListView.builder(
             shrinkWrap: true,
-            physics: NeverScrollableScrollPhysics(),
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: projects.length,
             itemBuilder: (context, index) {
-              return AnimatedSection(
+              return TweenAnimationBuilder<double>(
+                tween: Tween(begin: 0, end: _visible[index] ? 1 : 0),
+                duration: defaultDuration,
+                builder: (context, value, child) => Opacity(
+                  opacity: value,
+                  child: Transform.translate(
+                    offset: Offset(0, 30 * (1 - value)),
+                    child: child,
+                  ),
+                ),
                 child: ProjectsCard(
                   recommendation: projects[index],
                 ),
               );
             },
-            itemCount: projects.length,
           ),
         ],
       ),

--- a/lib/screens/home/components/skill_section.dart
+++ b/lib/screens/home/components/skill_section.dart
@@ -1,0 +1,110 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import '../../../constants.dart';
+import '../../../models/skill.dart';
+
+class SkillSection extends StatelessWidget {
+  final List<Skill> skills;
+  const SkillSection({Key? key, required this.skills}) : super(key: key);
+
+  Color _randomColor() {
+    final r = Random();
+    return Colors.primaries[r.nextInt(Colors.primaries.length)];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: defaultPadding),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Skills', style: Theme.of(context).textTheme.headlineSmall),
+          const SizedBox(height: defaultPadding),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final itemWidth = (constraints.maxWidth - defaultPadding) / 2;
+              return Wrap(
+                spacing: defaultPadding,
+                runSpacing: defaultPadding,
+                children: skills.map((s) {
+                  return SizedBox(
+                    width: itemWidth,
+                    child: _SkillBar(skill: s, color: _randomColor()),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SkillBar extends StatelessWidget {
+  final Skill skill;
+  final Color color;
+  const _SkillBar({required this.skill, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(skill.name, style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 6),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final barWidth = constraints.maxWidth;
+            final progressWidth = barWidth * skill.level;
+            return Stack(
+              clipBehavior: Clip.none,
+              children: [
+                Container(
+                  width: barWidth,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: darkColor,
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                ),
+                Container(
+                  width: progressWidth,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: color,
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                ),
+                Positioned(
+                  left: progressWidth - 8,
+                  top: -22,
+                  child: Column(
+                    children: [
+                      Text('${(skill.level * 100).round()}%'),
+                      Container(
+                        width: 16,
+                        height: 16,
+                        decoration: BoxDecoration(
+                          color: color,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+        const SizedBox(height: 6),
+        Text(
+          skill.description,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_profile/screens/home/components/my_blog.dart';
 import 'package:flutter_profile/screens/home/components/projects.dart';
 import 'package:flutter_profile/screens/main/main_screen.dart';
+import 'components/skill_section.dart';
+import '../../models/skill.dart';
 import '../../components/animated_section.dart';
 import 'components/home_banner.dart';
 import 'components/my_projects.dart';
@@ -25,6 +27,8 @@ class _HomeScreenState extends State<HomeScreen> {
 
   void _onMenu(String id) {
     final contextMap = {
+      'aboutMe': _aboutMe,
+      'skill': _skillKey,
       'career': _careerKey,
       'projects': _projectKey,
       'toys': _toyKey,
@@ -44,9 +48,9 @@ class _HomeScreenState extends State<HomeScreen> {
       children: [
         HomeBanner(),
         AnimatedSection(sectionKey: _aboutMe, child: Container()),
-        AnimatedSection(sectionKey: _skillKey, child: Container()),
+        AnimatedSection(sectionKey: _skillKey, child: SkillSection(skills: demoSkills)),
         AnimatedSection(sectionKey: _careerKey, child: Recommendations()),
-        AnimatedSection(sectionKey: _projectKey, child: Projects()),
+        AnimatedSection(sectionKey: _projectKey, child: Projects(scrollController: _scrollController)),
         AnimatedSection(sectionKey: _toyKey, child: MyProjects()),
         AnimatedSection(sectionKey: _postKey, child: MyPost()),
       ],


### PR DESCRIPTION
## Summary
- add `Skill` model and demo data
- create `SkillSection` widget with bullet progress bars
- insert skills into home screen and update menu anchors
- refactor projects list with scroll-triggered animations

## Testing
- `dart format lib/models/skill.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2ef7e26c832dbed99f5cac807ef4